### PR TITLE
:construction_worker: Add bump version and create release worklfow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,44 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semver type of new version (major / minor / patch)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump-version:
+    name: Bump version and create a new tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Setup Git
+        run: |
+          git config user.name 'Alexander Böhm'
+          git config user.email '3983539+mheob@users.noreply.github.com'
+
+      - name: Bump version
+        run: yarn version --${{ github.event.inputs.version }}
+
+      - name: Push latest version
+        run: git push origin main --follow-tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,15 @@
-name: Publish Extension
+name: Create Release
 
 on:
-  release:
-    types:
-      - created
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   publish:
+    name: Publish to VS Code Marketplace
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -25,3 +27,17 @@ jobs:
         run: yarn deploy
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create Release
+        run: gh release create ${{ github.ref }} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add the `bump-version` action and improve the `publish` action.

The `bump-version` action must be triggered manually with a specific semantic version type (major / minor / patch).

After bumping a new version, the `publish` action will be triggered to create a GitHub release and make the new version available on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=mheob.vscode-snippets).