### PR TITLE
:green_heart: Fix bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
`ssh-key: ${{ secrets.DEPLOY_KEY }}` throws the following error:

```console
Error: fatal: Could not read from remote repository.
```

This should be fixed now.