### PR TITLE
:arrow_up: Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-snippets",
   "displayName": "Snippets for Next.js, React in TypeScript",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Snippets for the development with Next.js, React in a TypeScript environment.",
   "categories": [
@@ -29,7 +29,7 @@
     "build": "ts-node scripts/generate-snippet-files.ts",
     "clean": "rimraf snippets",
     "predeploy": "yarn build",
-    "deploy": "vsce publish",
+    "deploy": "vsce publish --yarn --no-dependencies",
     "format": "prettier --write **/*.{ts,json,md,yml} --ignore-path .gitignore",
     "postinstall": "husky install",
     "lint": "eslint . --ext .ts",
@@ -74,8 +74,8 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^41.0.0",
     "husky": "^7.0.4",
-    "lint-staged": "^12.3.5",
-    "prettier": "^2.5.1",
+    "lint-staged": "^12.3.6",
+    "prettier": "^2.6.0",
     "prettier-plugin-jsdoc": "^0.3.31",
     "rimraf": "^3.0.2",
     "ts-node": "^10.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2036,9 +2036,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^12.3.5":
-  version: 12.3.5
-  resolution: "lint-staged@npm:12.3.5"
+"lint-staged@npm:^12.3.6":
+  version: 12.3.6
+  resolution: "lint-staged@npm:12.3.6"
   dependencies:
     cli-truncate: ^3.1.0
     colorette: ^2.0.16
@@ -2050,12 +2050,13 @@ __metadata:
     micromatch: ^4.0.4
     normalize-path: ^3.0.0
     object-inspect: ^1.12.0
+    pidtree: ^0.5.0
     string-argv: ^0.3.1
     supports-color: ^9.2.1
     yaml: ^1.10.2
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 6653c7078b36741e521e5f309b56bb75db198a05cbdd188124ff82a290e352ade3eb1e6080265729e19711ac08d190e300874af00e4e540b57b3c8f0690e2573
+  checksum: b5075addb79cefd3a01eb3e4b511cdbe255c86e80ac4f27c4ce90bbd5a6ef3765ec0c70ddc33e37d13aef54218b6026f52fcd0ed0ac9bf3a205a533b994ed387
   languageName: node
   linkType: hard
 
@@ -2718,6 +2719,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pidtree@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "pidtree@npm:0.5.0"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: 371cd14bbc9bdee2a6a44596dd521dd3565e223481e0b1afffdca3f1c29831850bfa7784114dc30d245d37e7d186cec035e036256b39f75d878d19498fe0df6a
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -2778,12 +2788,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "prettier@npm:2.5.1"
+"prettier@npm:^2.6.0":
+  version: 2.6.0
+  resolution: "prettier@npm:2.6.0"
   bin:
     prettier: bin-prettier.js
-  checksum: 21b9408476ea1c544b0e45d51ceb94a84789ff92095abb710942d780c862d0daebdb29972d47f6b4d0f7ebbfb0ffbf56cc2cfa3e3e9d1cca54864af185b15b66
+  checksum: 3e527ad62279676778a8404d18174d7ca2365ada4caba6eebbcdd9907d1187afd3bc6ade5b4e5f5d4549bb9fb71e45ca8930d71500017635524f8fc05bc52e93
   languageName: node
   linkType: hard
 
@@ -3746,8 +3756,8 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     eslint-plugin-unicorn: ^41.0.0
     husky: ^7.0.4
-    lint-staged: ^12.3.5
-    prettier: ^2.5.1
+    lint-staged: ^12.3.6
+    prettier: ^2.6.0
     prettier-plugin-jsdoc: ^0.3.31
     rimraf: ^3.0.2
     ts-node: ^10.7.0


### PR DESCRIPTION
Bump the following dependencies:

- `lint-staged` to `^12.3.6`
- `prettier` to `^2.6.0`